### PR TITLE
Uploading files with Cloudinary

### DIFF
--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,13 +1,39 @@
-'use client'
-import React from "react";
-import { CldUploadWidget } from "next-cloudinary";
+"use client";
+import React, { useState } from "react";
+import { CldImage, CldUploadWidget } from "next-cloudinary";
+
+interface CloudinaryResult {
+  public_id: string;
+}
 
 const UploadPage = () => {
+  const [publicId, setPublicId] = useState("");
+
   return (
-    <CldUploadWidget uploadPreset="NextAppUploadPreset">
-      {({ open }) => <button className="btn btn-primary" onClick={() => open()
-      }>Upload</button>}
-    </CldUploadWidget>
+    <>
+      {publicId && (
+        <CldImage
+          src={publicId}
+          width="300"
+          height="300"
+          alt="Uploaded image"
+        />
+      )}
+      <CldUploadWidget
+        uploadPreset="NextAppUploadPreset"
+        onSuccess={(result, widget) => {
+          if (result.event !== "success") return;
+          const info = result.info as CloudinaryResult;
+          setPublicId(info.public_id);
+        }}
+      >
+        {({ open }) => (
+          <button className="btn btn-primary" onClick={() => open()}>
+            Upload
+          </button>
+        )}
+      </CldUploadWidget>
+    </>
   );
 };
 

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -21,6 +21,35 @@ const UploadPage = () => {
       )}
       <CldUploadWidget
         uploadPreset="NextAppUploadPreset"
+        options={{
+          sources: ["local"],
+          maxFiles: 5,
+          maxFileSize: 5000000,
+          styles: {
+            palette: {
+              window: "#10173a",
+              sourceBg: "#20304b",
+              windowBorder: "#7171D0",
+              tabIcon: "#79F7FF",
+              inactiveTabIcon: "#8E9FBF",
+              menuIcons: "#CCE8FF",
+              link: "#72F1FF",
+              action: "#5333FF",
+              inProgress: "#00ffcc",
+              complete: "#33ff00",
+              error: "#cc3333",
+              textDark: "#000000",
+              textLight: "#ffffff",
+            },
+            fonts: {
+              default: null,
+              "'Poppins', sans-serif": {
+                url: "https://fonts.googleapis.com/css?family=Poppins",
+                active: true,
+              },
+            },
+          },
+        }}
         onSuccess={(result, widget) => {
           if (result.event !== "success") return;
           const info = result.info as CloudinaryResult;

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+import React from "react";
+import { CldUploadWidget } from "next-cloudinary";
+
+const UploadPage = () => {
+  return (
+    <CldUploadWidget uploadPreset="NextAppUploadPreset">
+      {({ open }) => <button className="btn btn-primary" onClick={() => open()
+      }>Upload</button>}
+    </CldUploadWidget>
+  );
+};
+
+export default UploadPage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-config-next": "14.2.15",
         "fast-sort": "^3.4.1",
         "next": "14.2.15",
+        "next-cloudinary": "^6.14.1",
         "postcss": "8.4.47",
         "prisma": "^5.20.0",
         "react": "18.3.1",
@@ -39,6 +40,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cloudinary-util/types": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/types/-/types-1.5.10.tgz",
+      "integrity": "sha512-n5lrm7SdAXhgWEbkSJKHZGnaoO9G/g4WYS6HYnq/k4nLj79sYfQZOoKjyR8hF2iyLRdLkT+qlk68RNFFv5tKew==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary-util/url-loader": {
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/url-loader/-/url-loader-5.10.4.tgz",
+      "integrity": "sha512-gHkdvOaV+rlcwuIT7Vqd0ts/H5bsH4+bwFten/gIZ8oRjzdTBvgIY3R6F8bbJt0pFIEfpFEQLe4rPkl0NNqEWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/util": "3.3.2",
+        "@cloudinary/url-gen": "1.15.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@cloudinary-util/util": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/util/-/util-3.3.2.tgz",
+      "integrity": "sha512-Cc0iFxzfl7fcOXuznpeZFGYC885Of/vDgccRDnhTe/8Rf8YKv2PjLtezyo0VgmdA/CpeZy29NCXAsf6liokbwg==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary/transformation-builder-sdk": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary/transformation-builder-sdk/-/transformation-builder-sdk-1.15.2.tgz",
+      "integrity": "sha512-oXYaW/whGaQVlR1O/ocp7vYcxaMAy3uGcQ8+8xjbfDCy/+c+zFIuP6JKI8L05kzqw7Wjh0cqzG+4u0X1UpPh+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/url-gen": "^1.7.0"
+      }
+    },
+    "node_modules/@cloudinary/url-gen": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary/url-gen/-/url-gen-1.15.0.tgz",
+      "integrity": "sha512-bjU67eZxLUgoRy/Plli4TQio7q6P31OYqnEgXxeN9TKXrzr6h0DeEdIUhKI9gy3HkEBWXWWJIPh7j7gkOJPnyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/transformation-builder-sdk": "^1.10.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3514,6 +3557,21 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-cloudinary": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/next-cloudinary/-/next-cloudinary-6.14.1.tgz",
+      "integrity": "sha512-TXTaTbpfFlc73rbQmXBhodvYu75mc2TuwzcMqhuCTsE8edHaVSdIlHNyolMZ7kIZGw33ojoXWkjoDSDo3T1yUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/url-loader": "5.10.4",
+        "@cloudinary-util/util": "^3.3.2"
+      },
+      "peerDependencies": {
+        "next": "^12 || ^13 || ^14 || >=15.0.0-rc",
+        "react": "^17 || ^18 || >=19.0.0-beta"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-config-next": "14.2.15",
     "fast-sort": "^3.4.1",
     "next": "14.2.15",
+    "next-cloudinary": "^6.14.1",
     "postcss": "8.4.47",
     "prisma": "^5.20.0",
     "react": "18.3.1",


### PR DESCRIPTION
Leverage Cloudinary to allow users to upload local files, rendering the image on a successful upload:
- installs and configures Cloudinary locally using env file
- creates upload page on route /upload
- renders an upload widget, rendering a child button for ui allowing user to upload
- configures widget to only accept 5 files at once with maximum size and styles
- renders image using state to pass the uploaded files public cloud id